### PR TITLE
BUGFIX:  user recipes page now displays

### DIFF
--- a/app/controllers/user_recipes_controller.rb
+++ b/app/controllers/user_recipes_controller.rb
@@ -1,6 +1,6 @@
 class UserRecipesController < ApplicationController
   def index
     user = User.find(params[:user_id])
-    @user_recipes = user.recipes
+    @recipes = user.recipes
   end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -87,6 +87,7 @@ class Ingredient < ActiveRecord::Base
                                                         "nutrition_tags",
                                                         "created_at",
                                                         "updated_at"]}).body
+  puts @json_response
 
   JSON.parse(@json_response)
   end


### PR DESCRIPTION
When we extracted the recipes display logic into an application
partial, it broke the code in users_recipes controller.
Specifically, the User recipes controller was senting the partial
the instance variable @user_recipes, and the partial was expecting
an instance variable named @recipes, so all of my recipes broke.

It now displayes correctly.
